### PR TITLE
更新三个失效的链接

### DIFF
--- a/site/_docs/templates.md
+++ b/site/_docs/templates.md
@@ -6,7 +6,7 @@ translators: [debbbbie, archersmind, TimoTokki, baiyangcao]
 update_date: 2016-10-20
 ---
 
-Jekyll 使用 [Liquid](http://wiki.shopify.com/Liquid) 模板语言，支持所有标准的 Liquid [标签](http://wiki.shopify.com/Logic)和[过滤器](http://wiki.shopify.com/Filters)。Jekyll 甚至增加了几个过滤器和标签，方便使用。
+Jekyll 使用 [Liquid](https://shopify.github.io/liquid/) 模板语言，支持所有标准的 Liquid [标签](https://shopify.github.io/liquid/basics/introduction/#tags)和[过滤器](https://shopify.github.io/liquid/basics/introduction/#filters)。Jekyll 甚至增加了几个过滤器和标签，方便使用。
 
 ## 过滤器
 


### PR DESCRIPTION
Shopify 更新了 Liquid 的链接，下面三个链接已经 404，我想可以使用 shopify.github.io/liquid 相关链接替代
http://wiki.shopify.com/Liquid
https://help.shopify.com/Filters
http://wiki.shopify.com/Logic